### PR TITLE
Implement draw pile and deck selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ De code bestaat uit losse modules voor spelregels, spelerslogica,
 AI en de gebruikersinterface.
 
 ## Spelen
-Installeer [LÖVE](https://love2d.org/) en start de game vanuit deze map:
+Installeer [LÖVE](https://love2d.org/) en start de game vanuit deze map. In het hoofdmenu kun je kiezen of je met één of twee kaartdecks speelt:
 
 ```bash
 love .

--- a/ai.lua
+++ b/ai.lua
@@ -1,10 +1,10 @@
--- Basic computer opponent behaviour
+--codex-- Basic computer opponent behaviour
 local utils = require("utils")
 local rules = require("rules")
-local deck = require("deck")
+local drawPile = require("drawpile")
 local ai = {}
 
--- Helper to ignore any '3' cards when determining the top card
+--codex-- Determine the effective top card while skipping any '3' values
 local function effective_top_card(pot)
     for i = #pot, 1, -1 do
         if pot[i].waarde ~= "3" then
@@ -14,7 +14,7 @@ local function effective_top_card(pot)
     return nil
 end
 
--- Heuristic function for card values
+--codex-- Ranking used by the AI to choose between playable cards
 local function get_heuristics(waarde)
     local map = {
         ["2"] = 11, ["3"] = 14, ["4"] = 1, ["5"] = 2,
@@ -25,14 +25,9 @@ local function get_heuristics(waarde)
     return map[waarde] or 0
 end
 
--- Helper: refill a hand to at least 5 cards if possible
-local function refill_hand(hand)
-    while #hand < 5 and deck.count() > 0 do
-        table.insert(hand, deck.draw())
-    end
-end
 
 -- Select the best playable card for the AI or nil when none is possible
+--codex-- Pick the most attractive playable card from the AI hand
 local function choose_card(game, pot)
     local hand = game.players[2].hand
     local top = effective_top_card(pot)
@@ -59,7 +54,7 @@ end
 -- Execute the AI's turn
 -- ...existing code...
 
--- Execute the AI's turn
+--codex-- Execute the AI's turn by choosing or picking up cards
 function ai.play(game, pot)
     local choice = choose_card(game, pot)
     if not choice then
@@ -75,13 +70,14 @@ function ai.play(game, pot)
         end
         return
     end
-    rules.handle_card_effects(game, 2, choice, pot)
-    refill_hand(game.players[2].hand) -- Only refill after a successful play
+    rules.handle_card_effects(game, 2, choice)
+    utils.refill_hand(game.players[2].hand, drawPile) -- refill after a successful play
 end
 
 -- ...existing code...
 
 -- Simple timer based update used to delay the AI's move
+--codex-- Timer helper so the AI waits a bit before acting
 function ai.update(dt, game, pot)
     if game.mode == "ai" and game.waitingForAI then
         game.aiTimer = game.aiTimer - dt

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,9 @@
+local config = {}
+
+--codex-- Default card display settings
+config.cardHeight = 160
+config.cardPadding = 15
+config.scale = config.cardHeight / 500
+config.cardWidth = 300 * config.scale
+
+return config

--- a/drawpile.lua
+++ b/drawpile.lua
@@ -1,10 +1,13 @@
-local deck = {}
+local drawPile = {}
 
-function deck.init()
-    deck.cards = {}
+--codex-- Load and shuffle a deck with the configured amount of sets
+function drawPile.init(count)
+    count = count or 1
+    drawPile.cards = {}
 
     local kaartmap = "png"
     local bestanden = love.filesystem.getDirectoryItems(kaartmap)
+    local basis = {}
 
     for _, bestand in ipairs(bestanden) do
         if bestand:match("%.png$") then
@@ -14,7 +17,7 @@ function deck.init()
             if waarde and kleur then
                 local afbeelding = love.graphics.newImage(kaartmap .. "/" .. bestand)
 
-                table.insert(deck.cards, {
+                table.insert(basis, {
                     kleur = kleur,
                     waarde = waarde,
                     afbeelding = afbeelding,
@@ -24,20 +27,26 @@ function deck.init()
         end
     end
 
+    for _ = 1, count do
+        for _, card in ipairs(basis) do
+            table.insert(drawPile.cards, card)
+        end
+    end
+
     -- Schudden
     math.randomseed(os.time())
-    for i = #deck.cards, 2, -1 do
+    for i = #drawPile.cards, 2, -1 do
         local j = math.random(i)
-        deck.cards[i], deck.cards[j] = deck.cards[j], deck.cards[i]
+        drawPile.cards[i], drawPile.cards[j] = drawPile.cards[j], drawPile.cards[i]
     end
 end
 
-function deck.draw()
-    return table.remove(deck.cards)
+function drawPile.draw()
+    return table.remove(drawPile.cards)
 end
 
-function deck.count()
-    return #deck.cards
+function drawPile.count()
+    return #drawPile.cards
 end
 
-return deck
+return drawPile

--- a/game.lua
+++ b/game.lua
@@ -1,6 +1,8 @@
--- Core game state without any AI logic. Card effects are handled in rules.lua
+--codex-- Core game state without any AI logic. Card effects are handled in rules.lua
 local game = {}
-local utils = require("utils")
+local utils    = require("utils")
+local drawPile = require("drawpile")
+local player = require("player")
 
 -- default mode is against the AI
 game.mode = "ai"
@@ -10,6 +12,10 @@ game.players = {
     { hand = {} }  -- Speler 2 (AI)
 }
 
+--codex-- Central discard pile and number of full decks used
+game.pot = {}
+game.deckCount = 1 --codex-- Selected number of decks to use
+
 game.currentPlayer = 1
 game.ronde = 0
 game.aiTimer = 0
@@ -17,12 +23,33 @@ game.waitingForAI = false
 game.nextMustBeUnder7 = false
 game.extraTurn = false
 
+--codex-- Initialize a new round with a chosen play mode
+function game.start(mode)
+    drawPile.init(game.deckCount)
+    player.init(drawPile)
+
+    game.mode = mode or "ai"
+    game.currentPlayer = 1
+    game.waitingForAI = false
+    game.nextMustBeUnder7 = false
+    game.extraTurn = false
+
+    game.pot = { drawPile.draw() }
+    game.ronde = 0
+
+    game.players[1].hand = player.hand
+    game.players[2].hand = {}
+    for i = 1, 5 do
+        table.insert(game.players[2].hand, drawPile.draw())
+    end
+end
 
 
 
-function game.play_card(playerIndex, kaart, pot)
-    -- Move the card from a player's hand to the discard pile
-    table.insert(pot, kaart)
+
+--codex-- Move a card from a player's hand onto the pile
+function game.play_card(playerIndex, kaart)
+    table.insert(game.pot, kaart)
     local hand = game.players[playerIndex].hand
     for i = 1, #hand do
         local k = hand[i]
@@ -46,3 +73,4 @@ end
 
 -- Expose the game state for other modules
 return game
+

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,6 @@
 -- Main entry file controlling scenes and user input
 
-local deck  = require("deck")
+local drawPile  = require("drawpile")
 local player = require("player")
 local ui    = require("ui")
 local rules = require("rules")
@@ -11,68 +11,32 @@ local utils = require("utils")
 local bgCanvas
 
 local scene = "menu"  -- "menu" | "playing"
-local selectedMode    -- "ai" | "human"
 
-local pot = {}
 local ronde = 0
 local ongeldigeZetTimer = 0
 
 toonPotOverlay = false
 
--- Helper: refill a hand to at least 5 cards if possible
-local function refill_hand(hand)
-    while #hand < 5 and deck.count() > 0 do
-        table.insert(hand, deck.draw())
-    end
-end
 
+--codex-- Initialize global resources
 function love.load()
     -- Pre-render the background felt texture once
     bgCanvas = utils.generate_green_felt_background(love.graphics.getWidth(), love.graphics.getHeight())
 end
 
-function startGame(mode)
-    selectedMode = mode
-    scene        = "playing"
 
-    deck.init()
-    player.init(deck)
-
-    pot = { deck.draw() }
-    ronde = 0
-    ongeldigeZetTimer = 0
-
-    game.mode = mode
-    game.currentPlayer = 1
-    game.waitingForAI  = false
-
-    -- koppel hand van de mens aan game-model
-    game.players[1].hand = player.hand
-
-    -- deel 7 kaarten aan de AI
-    game.players[2].hand = {}
-    for i = 1, 5 do
-        table.insert(game.players[2].hand, deck.draw())
-    end
-
-    -- Debug
-    print("\n=== AI-START ===")
-    print("AI heeft nu " .. #game.players[2].hand .. " kaarten op hand:")
-    for i, c in ipairs(game.players[2].hand) do
-        print(string.format("  [%d] %s of %s", i, c.waarde, c.kleur))
-    end
-end
-
+--codex-- Game loop update handling AI and timers
 function love.update(dt)
     if scene == "playing" then
         player.updateDragging()
         if ongeldigeZetTimer > 0 then
             ongeldigeZetTimer = ongeldigeZetTimer - dt
         end
-        ai.update(dt, game, pot)
+        ai.update(dt, game, game.pot)
     end
 end
 
+--codex-- Render the current scene and game state
 function love.draw()
     love.graphics.setBackgroundColor(0.1, 0.4, 0.1)
     if scene=="menu" then
@@ -81,8 +45,9 @@ function love.draw()
     end
     love.graphics.setColor(1, 1, 1)
     love.graphics.draw(bgCanvas, 0, 0)
-    
-    ui.draw_pot(pot, ongeldigeZetTimer > 0, toonPotOverlay)
+
+    ui.draw_pot(game.pot, ongeldigeZetTimer > 0, toonPotOverlay)
+    ui.draw_deck(drawPile)
     ui.draw_other_players()
     ui.draw_hand(player.hand, player.draggingCard)
     
@@ -90,22 +55,35 @@ function love.draw()
 
     love.graphics.setColor(0, 0, 0)
     love.graphics.print("Ronde: " .. ronde, 20, 20)
-    love.graphics.print("Kaarten in pot: " .. #pot, 20, 40)
+    love.graphics.print("Kaarten in pot: " .. #game.pot, 20, 40)
     
     --debug ish
     love.graphics.print("Speler aan zet: " .. game.currentPlayer, 20, 60)
     love.graphics.print("AI-timer: " .. string.format("%.2f", game.aiTimer), 20, 80)
 
-    buttons = drawActionButtons()
+    buttons = ui.draw_action_buttons()
 end
 
+--codex-- Handle mouse clicks for menus and card actions
 function love.mousepressed(x, y, button)
     if scene == "menu" and button == 1 then
-        if utils.inside(x, y, ui.aiX, ui.aiY, ui.aiW, ui.aiH) then
-            startGame("ai")
+        if utils.inside(x, y, ui.d1x, ui.d1y, ui.d1w, ui.d1h) then
+            game.deckCount = 1
+            return
+        elseif utils.inside(x, y, ui.d2x, ui.d2y, ui.d2w, ui.d2h) then
+            game.deckCount = 2
+            return
+        elseif utils.inside(x, y, ui.aiX, ui.aiY, ui.aiW, ui.aiH) then
+            game.start("ai")
+            scene = "playing"
+            ronde = 0
+            ongeldigeZetTimer = 0
             return
         elseif utils.inside(x, y, ui.hX, ui.hY, ui.hW, ui.hH) then
-            startGame("human")
+            game.start("human")
+            scene = "playing"
+            ronde = 0
+            ongeldigeZetTimer = 0
             return
         end
     end
@@ -122,8 +100,7 @@ function love.mousepressed(x, y, button)
         if x >= b.x and x <= b.x + b.w and y >= b.y and y <= b.y + b.h then
             if game.currentPlayer == 1 then
                 -- Alle kaarten uit de pot naar de speler overzetten
-                utils.transfer_all_cards(player.hand, pot)
-                -- refill_hand(player.hand)  -- REMOVE or COMMENT OUT THIS LINE
+                utils.transfer_all_cards(player.hand, game.pot)
                 print("Speler pakt pot op (" .. #player.hand .. " kaarten)")
                 game.next_turn()
             else
@@ -141,6 +118,7 @@ function love.mousepressed(x, y, button)
     end
 end
 
+--codex-- Drop a dragged card onto the table or return it
 function love.mousereleased(x, y, button)
     if button ~= 1 then return end
 
@@ -158,10 +136,10 @@ function love.mousereleased(x, y, button)
     end
 
     if inPot then
-        if rules.is_speelbaar(kaart, pot, game.nextMustBeUnder7) then
-            rules.handle_card_effects(game, 1, kaart, pot)
+        if rules.is_speelbaar(kaart, game.pot, game.nextMustBeUnder7) then
+            rules.handle_card_effects(game, 1, kaart)
             ronde = ronde + 1
-            refill_hand(player.hand)
+            utils.refill_hand(player.hand, drawPile)
         else
             table.insert(player.hand, kaart)
             ongeldigeZetTimer = 1.0

--- a/player.lua
+++ b/player.lua
@@ -1,4 +1,4 @@
--- Utility for the human player's hand and drag state
+--codex-- Utility for the human player's hand and drag state
 local player = {}
 
 player.hand = {}
@@ -12,11 +12,13 @@ function player.init(deck)
     end
 end
 
+--codex-- Begin dragging a card from the player's hand
 function player.startDrag(x, y)
-    local padding = 15
-    local kaartHoogte = 160
-    local schaal = kaartHoogte / 500
-    local kaartBreedte = 300 * schaal
+    local config = require("config")
+    local padding = config.cardPadding
+    local kaartHoogte = config.cardHeight
+    local schaal = config.scale
+    local kaartBreedte = config.cardWidth
 
     local w = love.graphics.getWidth()
     local x_start = (w - (#player.hand * (kaartBreedte + padding))) / 2
@@ -36,10 +38,12 @@ function player.startDrag(x, y)
     end
 end
 
+--codex-- Update drag offsets (UI queries mouse position directly)
 function player.updateDragging()
     -- geen xy-opslag nodig; UI berekent dat live
 end
 
+--codex-- Finish dragging and return the selected card
 function player.stopDrag()
     local kaart = player.draggingCard
     player.draggingCard = nil
@@ -47,3 +51,4 @@ function player.stopDrag()
 end
 
 return player
+

--- a/rules.lua
+++ b/rules.lua
@@ -1,7 +1,8 @@
--- Game rule helper functions
+--codex-- Game rule helper functions
 local rules = {}
 local utils = require("utils")
 
+--codex-- Check if a card can legally be played on the pile
 function rules.is_speelbaar(kaart, pot, onderZevenGedwongen)
     if not kaart then return false end
 
@@ -31,14 +32,14 @@ function rules.is_speelbaar(kaart, pot, onderZevenGedwongen)
     
 end
 
--- Resolve the effect of a played card and advance the game state
-function rules.handle_card_effects(game, playerIndex, kaart, pot)
-    -- Move the card from the hand to the pot first
-    game.play_card(playerIndex, kaart, pot)
+--codex-- Resolve card effects and update turn state
+function rules.handle_card_effects(game, playerIndex, kaart)
+    --codex-- Add the card to the pile then resolve its effect
+    game.play_card(playerIndex, kaart)
 
     -- 10 clears the discard pile and grants another turn
     if kaart.waarde == "10" then
-        utils.transfer_all_cards({}, pot) -- simply clear pot
+        utils.transfer_all_cards({}, game.pot) -- simply clear pot
         game.lastCardWas10 = true
         game.extraTurn = true
         if playerIndex == 2 then
@@ -68,3 +69,4 @@ function rules.handle_card_effects(game, playerIndex, kaart, pot)
     game.next_turn()
 end
 return rules
+

--- a/ui.lua
+++ b/ui.lua
@@ -2,10 +2,11 @@
 local ui = {}
 local game = require("game")
 
-local kaartHoogte = 120
-local schaal = kaartHoogte / 500
-local kaartBreedte = 300 * schaal
-local padding = 15
+local config = require("config")
+local kaartHoogte = config.cardHeight
+local schaal = config.scale
+local kaartBreedte = config.cardWidth
+local padding = config.cardPadding
 
 local cardBack = love.graphics.newImage("/png/back.png")
 
@@ -14,7 +15,24 @@ local player = require("player") -- <-- dit is essentieel!
 local groteTitelFont = love.graphics.newFont(40)
 local kleineTitelFont = love.graphics.newFont(20)
 
+--codex-- Draw remaining draw pile as stacked card backs with a counter
+function ui.draw_deck(deck)
+    local w, h = love.graphics.getWidth(), love.graphics.getHeight()
+    local kaart_hoogte = 140
+    local x = w / 2 + 120
+    local y = h / 2 - 70
+    local schaal = kaart_hoogte / cardBack:getHeight()
+    local count = deck.count()
+    local zichtbaar = math.min(count, 5)
+    for i = 0, zichtbaar - 1 do
+        love.graphics.setColor(1, 1, 1, 1 - i * 0.15)
+        love.graphics.draw(cardBack, x + i * 2, y - i * 2, math.rad(-i * 2), schaal, schaal)
+    end
+    love.graphics.setColor(0, 0, 0)
+    love.graphics.printf("Deck: " .. count, x - 30, y + kaart_hoogte + 10, 120, "center")
+end
 
+--codex-- Draw the pile of played cards and optional overlay
 function ui.draw_pot(pot, ongeldigeZetActief, toonOverlay)
     local w, h = love.graphics.getWidth(), love.graphics.getHeight()
     local x, y = w / 2 - 50, h / 2 - 70
@@ -94,7 +112,7 @@ if toonOverlay then
 end
 end
 
---andere speler kaarten tekenen
+--codex-- Draw the AI player's face-down cards
 function ui.draw_other_players()
     local game = require("game")
     local hand = game.players[2].hand
@@ -121,7 +139,7 @@ function ui.draw_other_players()
     end
 end
 
-
+--codex-- Render the player's hand and follow the dragged card
 function ui.draw_hand(hand, draggingCard)
     local w, h = love.graphics.getWidth(), love.graphics.getHeight()
     local kaart_hoogte = 160
@@ -150,6 +168,7 @@ end
 
 -----------------------------------------------------------------
 -- MENU  --------------------------------------------------------
+--codex-- Main menu with mode selection buttons
 function ui.draw_menu(mouseX, mouseY)
     local w,h = love.graphics.getWidth(), love.graphics.getHeight()
     love.graphics.setFont(groteTitelFont)
@@ -170,11 +189,29 @@ function ui.draw_menu(mouseX, mouseY)
 
     ui.btnAI,  ui.aiX,  ui.aiY,  ui.aiW,  ui.aiH  = button("Tegen AI spelen", 260)
     ui.btnH2H, ui.hX,   ui.hY,   ui.hW,   ui.hH   = button("Tegen speler (WIP)", 340)
+
+    local function deckBtn(label,x,y,selected)
+        local bw,bh = 120,40
+        local hover = mouseX>x and mouseX<x+bw and mouseY>y and mouseY<y+bh
+        love.graphics.setColor(selected and 0.4 or hover and 0.8 or 0.6,0.6,0.6)
+        love.graphics.rectangle("fill",x,y,bw,bh,8,8)
+        love.graphics.setColor(0,0,0)
+        love.graphics.printf(label,x,y+10,bw,"center")
+        return hover,x,y,bw,bh
+    end
+
+    love.graphics.setColor(1,1,1)
+    love.graphics.printf("Aantal decks:",0, 410, w, "center")
+    ui.oneX, ui.oneY = (w-260)/2, 440
+    ui.twoX, ui.twoY = ui.oneX+140, 440
+    ui.d1, ui.d1x, ui.d1y, ui.d1w, ui.d1h = deckBtn("1 Deck", ui.oneX, ui.oneY, game.deckCount==1)
+    ui.d2, ui.d2x, ui.d2y, ui.d2w, ui.d2h = deckBtn("2 Decks", ui.twoX, ui.twoY, game.deckCount==2)
 end
 
 
 -- Pickup + Pot bekijkknoppen gecombineerd en gecentreerd
-function drawActionButtons()
+--codex-- Draw buttons to pick up the pile or view it
+function ui.draw_action_buttons()
     local w, h = love.graphics.getWidth(), love.graphics.getHeight()
     local btnW, btnH = 150, 40
     local spacing = 20

--- a/utils.lua
+++ b/utils.lua
@@ -41,4 +41,13 @@ function utils.transfer_all_cards(dest, src)
     end
 end
 
+--codex-- Ensure a hand always has at least `count` cards by drawing
+--codex-- from the deck module.
+function utils.refill_hand(hand, deck, count)
+    count = count or 5
+    while #hand < count and deck.count() > 0 do
+        table.insert(hand, deck.draw())
+    end
+end
+
 return utils


### PR DESCRIPTION
## Summary
- rename `deck.lua` to `drawpile.lua` and allow multiple decks
- show stacked draw pile with remaining card counter
- add menu buttons to choose 1 or 2 decks
- store deck count in `game.deckCount` and use when starting
- update README with deck selection info

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68470730b00c8325a94337c3a50e501b