### PR TITLE
Fix scrolling card hit detection

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -92,10 +92,10 @@ function love.mousepressed(x, y, button)
 
     if scene == "playing" and button == 1 then
         local positions = ui.get_card_positions(player.players[1].hand)
-        for i, pos in ipairs(positions) do
+        for _, pos in ipairs(positions) do
             if utils.inside(x, y, pos.x, pos.y, pos.w, pos.h) then
                 -- phase is game.state, wat "selectFaceUp" of "playing" hoort te zijn
-                player.toggle_select(player.players[1].hand, i, game.state)
+                player.toggle_select(player.players[1].hand, pos.index, game.state)
                 return
             end
         end

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -330,14 +330,18 @@ function ui.get_card_positions(hand)
     local cardSpace = kaart_breedte + padding
     local visibleCards = math.floor((boxWidth + padding) / cardSpace)
     local scrollOffset = require("src.player").scrollOffset or 0
-    local fractional = scrollOffset % cardSpace
 
-    local x_start = 40 + (boxWidth - visibleCards * cardSpace) / 2 - fractional
+    -- bepaal welke indices zichtbaar zijn --codex
+    local beginIndex = math.floor(scrollOffset / cardSpace) + 1
+    local eindIndex = math.min(#hand, beginIndex + visibleCards - 1)
+    local fractional = scrollOffset % cardSpace
+    local contentWidth = visibleCards * cardSpace
+    local x_start = 40 + (boxWidth - contentWidth) / 2 - fractional
     local y = h - kaart_hoogte - 50
 
-    for i, kaart in ipairs(hand) do
-        local x = x_start + (i - 1) * (kaart_breedte + padding)
-        table.insert(positions, { x = x, y = y, w = kaart_breedte, h = kaart_hoogte })
+    for i = beginIndex, eindIndex do
+        local x = x_start + (i - beginIndex) * (kaart_breedte + padding)
+        table.insert(positions, { x = x, y = y, w = kaart_breedte, h = kaart_hoogte, index = i })
     end
 
     return positions


### PR DESCRIPTION
## Summary
- compute visible card indices in `ui.get_card_positions`
- return only visible card positions and store the original index
- use the returned index for click detection in `main.lua`

## Testing
- `luacheck src/ui.lua main.lua` *(fails: command not found)*
- `love .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7412f46c832593d0d5525576fa9c