### PR TITLE
Add debug flag for utils logging

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -6,4 +6,7 @@ config.cardPadding = 15
 config.scale = config.cardHeight / 500
 config.cardWidth = 300 * config.scale
 
+--codex-- Toggle verbose debug output in helper modules
+config.debug = false
+
 return config

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1,6 +1,7 @@
 -- Collection of small reusable helper functions
 
 local utils = {}
+local config = require("src.config")
 
 -- Convert card value names to a numeric ranking.
 function utils.numeric_value(value)
@@ -44,10 +45,14 @@ end
 function utils.effective_top_card(pot)
     for i = #pot, 1, -1 do
         if pot[i].waarde ~= "3" then
-            print("[UTILS] effective_top_card: " .. pot[i].waarde)
+            if config.debug then
+                print("[UTILS] effective_top_card: " .. pot[i].waarde)
+            end
             return pot[i]
         else
-            print("[UTILS] 3 GEDTECTEERDE")
+            if config.debug then
+                print("[UTILS] 3 GEDTECTEERDE")
+            end
             -- Special case for 3: skip it")
         end
     end


### PR DESCRIPTION
## Summary
- add `config.debug` option
- silence utility logging unless debug is enabled

## Testing
- `luac` was unavailable so no syntax validation was run

------
https://chatgpt.com/codex/tasks/task_e_685a74129b7083259db1e5f79abf6c4d