### PR TITLE
Bug fixes and utils cleanup

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -25,12 +25,7 @@ local config = require("config")
 -- Hulp: bepaal in welke fase speler i zit
 --------------------------------------------------------------------
 local function phase_for_player(i)
-    local p = require("player").players[i]
-    if     #p.hand     > 0 then return "playingHand"
-    elseif #p.faceUp   > 0 then return "playingOpen"
-    elseif #p.faceDown > 0 then return "playingBlind"
-    else                         return "out"
-    end
+    return require("utils").phase_for_player(i)
 end
 
 

--- a/main.lua
+++ b/main.lua
@@ -63,7 +63,11 @@ function love.draw()
     love.graphics.print("Speler aan zet: " .. game.currentPlayer, 20, 60)
     love.graphics.print("AI-timer: " .. string.format("%.2f", game.aiTimer), 20, 80)
 
-    buttons = ui.draw_action_buttons()
+    if game.state ~= "setupSelectOpen" and game.state ~= "setupAISelect" then
+        buttons = ui.draw_action_buttons()
+    else
+        buttons = nil
+    end
 end
 
 --codex-- Handle mouse clicks for menus, buttons en kaart-acties
@@ -179,6 +183,9 @@ function love.mousepressed(x, y, button)
     --  PLAYING-SCENE (knoppen + kaart-selectie)
     ------------------------------------------------------------------
     if scene == "playing" and button == 1 then
+        if game.state == "setupSelectOpen" or game.state == "setupAISelect" then
+            return
+        end
         ----------------------------------------------------------------
         -- 1.  UI-knoppen (Pak pot / Speel / Bekijk pot / Deselect)
         --     ⇒ bij hit altijd meteen RETURN

--- a/player.lua
+++ b/player.lua
@@ -42,13 +42,6 @@ function player.init(deck)
 end
 
 -- tel hoeveel kaarten momenteel geselecteerd zijn
-function player.count_selected(hand)
-    local c = 0
-    for _,k in ipairs(hand) do
-        if k.selected then c = c + 1 end
-    end
-    return c
-end
 
 function player.toggle_select(hand, index, phase)
     local kaart = hand[index]

--- a/rules.lua
+++ b/rules.lua
@@ -197,6 +197,8 @@ function rules.play_selected_open(game, playerIndex)
             -- kaart + pot terug naar hand
             utils.transfer_all_cards(speler.hand, game.pot)
             for _, c in ipairs(selected) do table.insert(speler.hand, c) end
+            utils.deselect_all(speler.hand)
+            game.next_turn()
             return false
         end
     end
@@ -205,8 +207,10 @@ function rules.play_selected_open(game, playerIndex)
     for _, k in ipairs(selected) do
         rules.handle_card_effects(game, playerIndex, k)
     end
-    -- checken of faceup nu leeg is.
-    utils.update_phase_for_player(game, playerIndex)
+    -- checken of faceup nu leeg is wanneer dezelfde speler aan zet blijft
+    if game.currentPlayer == playerIndex then
+        utils.update_phase_for_player(game, playerIndex)
+    end
     -- 4) reset selectievlaggen in resterende faceUp
     for _, k in ipairs(speler.faceUp) do k.selected = false end
     return true

--- a/utils.lua
+++ b/utils.lua
@@ -67,6 +67,17 @@ function utils.deselect_all(t)
     for _, k in ipairs(t) do k.selected = false end
 end
 
+-- Count how many cards are currently selected in a list
+function utils.count_selected(cards)
+    local c = 0
+    for _, k in ipairs(cards) do
+        if k.selected then
+            c = c + 1
+        end
+    end
+    return c
+end
+
 
 --------------------------------------------------------------------
 --  Hulpfunctie: bepaal nieuwe fase voor een speler
@@ -82,6 +93,16 @@ function utils.update_phase_for_player(game, idx)
         game.state = "playingBlind"
     else
         game.state = "finished"   -- speler heeft echt alles weg
+    end
+end
+
+-- Return the phase string for a given player without modifying the game
+function utils.phase_for_player(idx)
+    local p = require("player").players[idx]
+    if     #p.hand     > 0 then return "playingHand"
+    elseif #p.faceUp   > 0 then return "playingOpen"
+    elseif #p.faceDown > 0 then return "playingBlind"
+    else                         return "out"
     end
 end
 


### PR DESCRIPTION
## Summary
- centralize phase lookup logic and card selection helper in `utils`
- fix invalid face-up play logic and only update phase if turn continues
- hide action buttons during setup
- skip button handling while selecting open cards
- remove unused `player.count_selected`

## Testing
- `luacheck .` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fd5e10f88325859be03f2b8a6e7f