### PR TITLE
Revamp game UI layout for responsive design

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -2,15 +2,15 @@
 local ui = {}
 
 --- Module dependencies -----------------------------------------------------------
-local config           = require("config")
-local player           = require("player")
-local net              = require("net")
-local rules            = require("rules")
-local utils            = require("utils")
-local drawPileModule   = require("drawpile")
+local config         = require("config")
+local player         = require("player")
+local net            = require("net")
+local rules          = require("rules")
+local utils          = require("utils")
+local drawPileModule = require("drawpile")
 
 --- Assets & constants -----------------------------------------------------------
-local cardBack         = love.graphics.newImage("png/back.png")
+local cardBack       = love.graphics.newImage("png/back.png")
 local DESIGN_W, DESIGN_H = 1280, 720
 local SAFE_PAD_BASE      = 16
 local DOUBLE_TAP_TIME    = 0.30
@@ -22,6 +22,7 @@ ui.safe         = SAFE_PAD_BASE
 ui.minTap       = 40
 ui.cardW        = config.cardWidth or 140
 ui.cardH        = config.cardHeight or 200
+ui.cardSizes    = {}
 
 ui.fontBig      = nil
 ui.fontSmall    = nil
@@ -30,11 +31,11 @@ ui.fontSmallSize= nil
 
 ui.areas        = {}
 ui.centerLayout = {}
-ui.buttons      = {}
+ui.buttons      = { active = nil, activeId = nil }
 ui.handHitboxes = {}
 ui.faceUpHitboxes = {}
 ui.faceDownRect = nil
-ui.handMetrics  = { step = 0, visible = 0, viewport = 0, hitW = 0 }
+ui.handMetrics  = { viewport = 0, visible = 0, step = 0, hitW = 0 }
 ui.pointer      = { x = 0, y = 0 }
 ui.lastTap      = { index = nil, time = 0 }
 ui.statusLines  = {}
@@ -45,11 +46,16 @@ ui.overlayRect  = nil
 ui.drag         = { active = false }
 
 --- Helpers ----------------------------------------------------------------------
-local function clamp(min, value, max)
-    if max < min then max = min end
-
-    if value < min then return min end
-    if value > max then return max end
+local function clamp(minValue, value, maxValue)
+    if maxValue < minValue then
+        maxValue = minValue
+    end
+    if value < minValue then
+        return minValue
+    end
+    if value > maxValue then
+        return maxValue
+    end
     return value
 end
 
@@ -62,7 +68,6 @@ end
 local function ensureFonts()
     local bigSize   = math.max(22, math.floor(28 * ui.scale))
     local smallSize = math.max(16, math.floor(18 * ui.scale))
-
 
     if not ui.fontBig or ui.fontBigSize ~= bigSize then
         ui.fontBig = love.graphics.newFont(bigSize)
@@ -155,29 +160,13 @@ local function hintText(game, isTurn, playable)
     elseif game.state == "playingBlind" then
         return isTurn and "Raak de blinde stapel aan om een kaart te onthullen." or "Wachten op de tegenstander."
     elseif game.state == "playingOpen" then
-        if not isTurn then
-            return "De tegenstander is aan de beurt."
-        end
+        if not isTurn then return "De tegenstander is aan de beurt." end
         return playable and "Speel geselecteerde open kaart." or "Selecteer een open kaart om te spelen."
     else
-        if not isTurn then
-            return "De tegenstander is aan zet."
-        end
-        if playable then
-            return "Speel de geselecteerde kaart(en)."
-        end
+        if not isTurn then return "De tegenstander is aan zet." end
+        if playable then return "Speel de geselecteerde kaart(en)." end
         return "Selecteer kaarten met dezelfde waarde om te spelen."
     end
-
-    ui.handView = {
-        xStart = xStart,
-        viewportW = viewportW,
-        contentW = contentW,
-        maxScroll = maxScroll,
-        offset = pData.scrollOffset,
-        hitboxes = {},
-    }
-    return ui.handView
 end
 
 local function computeHandView(pData)
@@ -188,20 +177,17 @@ local function computeHandView(pData)
 
     local metrics = ui.handMetrics
     local cards = pData.hand or {}
-    pData.scrollOffset = pData.scrollOffset or player.scrollOffset or 0
-
-    local contentW = (#cards > 0) and (ui.cardW + (math.max(0, #cards - 1) * metrics.step)) or 0
+    local cardW = metrics.cardW or (ui.cardSizes.hand and ui.cardSizes.hand.w) or ui.cardW
+    local contentW = (#cards > 0) and (cardW + (math.max(0, #cards - 1) * metrics.step)) or 0
     local maxScroll = math.max(0, contentW - metrics.viewport)
-    if pData.scrollOffset > maxScroll then pData.scrollOffset = maxScroll end
-    if pData.scrollOffset < 0 then pData.scrollOffset = 0 end
-
-    player.scrollOffset = pData.scrollOffset
+    local offset = clamp(0, pData.scrollOffset or 0, maxScroll)
+    pData.scrollOffset = offset
 
     local xStart
     if contentW <= metrics.viewport then
         xStart = rect.x + (rect.w - contentW) / 2
     else
-        xStart = rect.x + ui.pad - pData.scrollOffset
+        xStart = rect.x + ui.pad - offset
     end
 
     return {
@@ -212,6 +198,7 @@ local function computeHandView(pData)
         step = metrics.step,
         hitW = metrics.hitW,
         rect = rect,
+        cardW = cardW,
     }
 end
 
@@ -226,13 +213,7 @@ local function formatStatusLines(game, isTurn)
 
     if game.nextMustBeUnder7 then
         table.insert(lines, "Volgende kaart ≤ 7")
-
     end
-end
-
-local function clearScissor()
-    love.graphics.setScissor()
-end
 
     if game.invalidTimer and game.invalidTimer > 0 then
         table.insert(lines, "Ongeldige zet")
@@ -243,8 +224,6 @@ end
     else
         table.insert(lines, "Scroll met wiel of sleep om de hand te bekijken")
     end
-    return selected
-end
 
     return lines
 end
@@ -258,188 +237,323 @@ local function drawPanelBackground(rect, alpha)
     love.graphics.setColor(1, 1, 1, 1)
 end
 
---- Layout ----------------------------------------------------------------------
+--- Layout -----------------------------------------------------------------------
 function ui.layout(w, h)
     ui.viewportWidth, ui.viewportHeight = w, h
 
     local scaleGuess = math.min(w / DESIGN_W, h / DESIGN_H)
-    ui.scale = clamp(0.75, scaleGuess, 1.2)
+    ui.scale = clamp(0.45, scaleGuess, 1.25)
 
     ui.safe   = math.floor(SAFE_PAD_BASE * ui.scale)
     ui.pad    = math.max(4, math.floor((config.cardPadding or 16) * ui.scale))
-    ui.cardW  = math.floor((config.cardWidth or 140) * ui.scale)
-    ui.cardH  = math.floor((config.cardHeight or 200) * ui.scale)
-    ui.minTap = math.max(30, math.floor(40 * ui.scale))
-    ui.compact = (w < (config.phoneBreakpoint or config.phoneBP or 800))
+    ui.minTap = math.max(30, math.floor(44 * ui.scale))
+
+    local baseW = config.cardWidth or 140
+    local baseH = config.cardHeight or 200
+    local aspect = baseW / baseH
+
+    ui.cardH = math.max(24, math.floor(baseH * ui.scale))
+    ui.cardW = math.max(16, math.floor(ui.cardH * aspect + 0.5))
+
+    local function makeSize(mult)
+        local hSize = math.max(18, math.floor(ui.cardH * mult))
+        local wSize = math.max(12, math.floor(hSize * aspect + 0.5))
+        return { w = wSize, h = hSize }
+    end
+
+    ui.cardSizes = {
+        hand = { w = ui.cardW, h = ui.cardH },
+        open = makeSize(0.85),
+        faceDown = makeSize(0.65),
+        deck = makeSize(0.8),
+        opponent = makeSize(0.8),
+    }
 
     ensureFonts()
 
-    local contentW = math.max(0, w - 2 * ui.safe)
-    local topH = math.max(math.floor(h * 0.12), ui.fontBig:getHeight() + ui.fontSmall:getHeight() + ui.pad * 2)
-    local gutter = ui.pad
+    local innerW = math.max(0, w - 2 * ui.safe)
+    local buttonH = math.max(ui.minTap, math.floor(ui.fontBig:getHeight() + ui.pad * 1.2))
 
-    ui.areas.hudLeftTop = {
+    ui.areas.buttons = {
         x = ui.safe,
-        y = ui.safe,
-        w = math.max(0, math.floor((contentW - gutter) * 0.5)),
-        h = topH,
+        y = h - ui.safe - buttonH,
+        w = innerW,
+        h = buttonH,
     }
 
-    local rightX = ui.areas.hudLeftTop.x + ui.areas.hudLeftTop.w + gutter
-    ui.areas.hudRightTop = {
-        x = rightX,
-        y = ui.safe,
-        w = math.max(0, contentW - ui.areas.hudLeftTop.w - gutter),
-        h = topH,
-    }
+    local cursorBottom = ui.areas.buttons.y - ui.pad
 
-    local statusH = math.max(ui.minTap * 0.75, ui.fontSmall:getHeight() + ui.pad * 1.2)
-    ui.areas.statusBottom = {
-        x = ui.safe,
-        y = h - ui.safe - statusH,
-        w = contentW,
-        h = statusH,
-    }
-
-    local centerY = ui.areas.hudLeftTop.y + topH + ui.pad
-    local centerMaxH = ui.areas.statusBottom.y - ui.pad - centerY
-    local centerH = math.max(ui.cardH + ui.pad * 2, math.min(math.floor(h * 0.32), centerMaxH))
-    ui.areas.center = {
-        x = ui.safe,
-        y = centerY,
-        w = contentW,
-        h = centerH,
-    }
-
-    local bottomTop = ui.areas.center.y + ui.areas.center.h + ui.pad
-    local bottomBottom = ui.areas.statusBottom.y - ui.pad
-    local bottomH = math.max(0, bottomBottom - bottomTop)
-
-    local handH = math.min(bottomH, ui.cardH + ui.pad * 2)
-    handH = math.max(math.floor(ui.cardH + ui.pad), handH)
-    local oppH = math.max(0, bottomH - handH - ui.pad)
-
-    ui.areas.topOpponent = {
-        x = ui.safe,
-        y = bottomTop,
-        w = contentW,
-        h = oppH,
-    }
-
-    local handY = bottomTop + (oppH > 0 and (oppH + ui.pad) or 0)
+    local handH = ui.cardSizes.hand.h + ui.pad * 2
     ui.areas.handBottom = {
         x = ui.safe,
-        y = handY,
-        w = contentW,
-        h = math.max(0, bottomH - (handY - bottomTop)),
+        y = cursorBottom - handH,
+        w = innerW,
+        h = handH,
     }
+    cursorBottom = ui.areas.handBottom.y - ui.pad
+
+    local faceBlockH = ui.cardSizes.faceDown.h + ui.cardSizes.open.h + ui.pad * 3
+    ui.areas.faceBottom = {
+        x = ui.safe,
+        y = cursorBottom - faceBlockH,
+        w = innerW,
+        h = faceBlockH,
+    }
+    cursorBottom = ui.areas.faceBottom.y - ui.pad
+
+    local centralTop = ui.safe
+    local centralBottom = math.max(cursorBottom, centralTop + ui.minTap * 4)
+    local centralHeight = centralBottom - centralTop
+
+    ui.compact = (w < (config.phoneBreakpoint or config.phoneBP or 900)) or innerW < ui.minTap * 9
+
+    local infoW = innerW
+    local fieldX = ui.safe
+    local fieldW = innerW
+
+    if not ui.compact then
+        infoW = math.min(innerW * 0.32, math.max(ui.minTap * 4, math.floor(320 * ui.scale + 0.5)))
+        fieldW = innerW - infoW - ui.pad
+        if fieldW < ui.minTap * 6 then
+            ui.compact = true
+            infoW = innerW
+            fieldX = ui.safe
+            fieldW = innerW
+        else
+            fieldX = ui.safe + infoW + ui.pad
+        end
+    end
+
+    local labelHeight = math.floor(ui.fontSmall:getHeight() + ui.pad * 0.6)
+
+    local sections
+    if ui.compact then
+        sections = {
+            { name = "oppHand", h = ui.cardSizes.opponent.h + labelHeight + ui.pad, min = ui.cardSizes.opponent.h + math.floor(labelHeight * 0.6) },
+            { name = "oppFace", h = ui.cardSizes.faceDown.h + labelHeight + math.floor(ui.pad * 0.6), min = ui.cardSizes.faceDown.h + math.floor(labelHeight * 0.4) },
+            { name = "info",    h = math.max(ui.minTap * 3, math.floor(centralHeight * 0.28)), min = math.max(ui.minTap * 2, ui.fontBig:getHeight() * 2) },
+            { name = "center",  h = math.max(ui.cardSizes.deck.h + labelHeight + ui.pad * 3, math.floor(centralHeight * 0.35)), min = math.max(ui.minTap * 2, ui.cardSizes.deck.h + labelHeight) },
+        }
+    else
+        sections = {
+            { name = "oppHand", h = ui.cardSizes.opponent.h + labelHeight + ui.pad, min = ui.cardSizes.opponent.h + math.floor(labelHeight * 0.6) },
+            { name = "oppFace", h = ui.cardSizes.faceDown.h + labelHeight + math.floor(ui.pad * 0.6), min = ui.cardSizes.faceDown.h + math.floor(labelHeight * 0.4) },
+            { name = "center",  h = math.max(ui.cardSizes.deck.h + labelHeight + ui.pad * 3, math.floor(centralHeight * 0.45)), min = math.max(ui.minTap * 2, ui.cardSizes.deck.h + labelHeight) },
+        }
+    end
+
+    local function adjustSections(list, availableHeight)
+        if #list == 0 then return end
+        local gapCount = #list - 1
+        local totalSpacing = gapCount * ui.pad
+        local availableForSections = math.max(availableHeight - totalSpacing, 0)
+        local sumBase, sumMin = 0, 0
+        for _, item in ipairs(list) do
+            item.h = math.floor(item.h + 0.5)
+            item.min = math.floor(item.min + 0.5)
+            if item.h < item.min then item.h = item.min end
+            sumBase = sumBase + item.h
+            sumMin = sumMin + item.min
+        end
+        if sumBase > availableForSections then
+            local adjustable = math.max(sumBase - sumMin, 0)
+            local reduction = sumBase - availableForSections
+            if adjustable <= 0 then
+                for _, item in ipairs(list) do
+                    item.h = item.min
+                end
+            else
+                local scale = reduction / adjustable
+                local removed = 0
+                for _, item in ipairs(list) do
+                    local extra = item.h - item.min
+                    if extra > 0 then
+                        local reduce = math.min(extra, math.floor(extra * scale + 0.5))
+                        item.h = item.h - reduce
+                        removed = removed + reduce
+                    end
+                end
+                local remaining = reduction - removed
+                if remaining > 0 then
+                    for _, item in ipairs(list) do
+                        local extra = item.h - item.min
+                        if extra > 0 and remaining > 0 then
+                            local step = math.min(extra, remaining)
+                            item.h = item.h - step
+                            remaining = remaining - step
+                        end
+                    end
+                end
+            end
+        elseif sumBase < availableForSections then
+            local leftover = availableForSections - sumBase
+            for index = #list, 1, -1 do
+                local item = list[index]
+                if item.name == "center" or index == #list then
+                    item.h = item.h + leftover
+                    break
+                end
+            end
+        end
+    end
+
+    adjustSections(sections, centralHeight)
+
+    if ui.compact then
+        local y = centralTop
+        local oppHand = sections[1]
+        ui.areas.opponentHand = { x = ui.safe, y = y, w = innerW, h = oppHand.h }
+        y = y + oppHand.h + ui.pad
+
+        local oppFace = sections[2]
+        ui.areas.opponentFaceDown = { x = ui.safe, y = y, w = innerW, h = oppFace.h }
+        y = y + oppFace.h + ui.pad
+
+        local infoSec = sections[3]
+        ui.areas.infoPanel = { x = ui.safe, y = y, w = infoW, h = infoSec.h }
+        y = y + infoSec.h + ui.pad
+
+        local centerSec = sections[4]
+        local centerH = math.max(centerSec.h, centralTop + centralHeight - y)
+        ui.areas.center = { x = ui.safe, y = y, w = innerW, h = centerH }
+    else
+        local y = centralTop
+        local oppHand = sections[1]
+        ui.areas.opponentHand = { x = fieldX, y = y, w = fieldW, h = oppHand.h }
+        y = y + oppHand.h + ui.pad
+
+        local oppFace = sections[2]
+        ui.areas.opponentFaceDown = { x = fieldX, y = y, w = fieldW, h = oppFace.h }
+        y = y + oppFace.h + ui.pad
+
+        local centerSec = sections[3]
+        local centerH = math.max(centerSec.h, centralTop + centralHeight - y)
+        ui.areas.center = { x = fieldX, y = y, w = fieldW, h = centerH }
+
+        ui.areas.infoPanel = { x = ui.safe, y = centralTop, w = infoW, h = centralHeight }
+    end
 
     local rect = ui.areas.handBottom
     local viewport = math.max(1, rect.w - ui.pad * 2)
-    local visible = math.max(6, math.floor(viewport / math.max(1, ui.cardW * 0.6)))
-    local step = math.max(1, math.floor(math.min(ui.cardW, viewport / math.max(1, visible))))
+    local step = math.max(1, math.floor(ui.cardSizes.hand.w * 0.55))
+    local visible = math.max(1, math.floor(viewport / step))
+    local hitW = math.max(ui.minTap, math.floor(ui.cardSizes.hand.w * 0.9))
 
+    local prevButtons = ui.buttons or {}
     ui.handMetrics = {
         viewport = viewport,
         visible = visible,
         step = step,
-        hitW = math.max(ui.minTap, step),
+        hitW = hitW,
+        cardW = ui.cardSizes.hand.w,
     }
 
-    local prevButtons = ui.buttons or {}
-    ui.buttons = {
-        active = prevButtons.active,
-        activeId = prevButtons.activeId,
-    }
-    ui.centerLayout = {}
+    ui.buttons = { active = prevButtons.active, activeId = prevButtons.activeId }
+    ui.centerLayout = { buttons = {
+        x = ui.areas.buttons.x,
+        y = ui.areas.buttons.y,
+        w = ui.areas.buttons.w,
+        h = ui.areas.buttons.h,
+    } }
+
     ui.handHitboxes = {}
     ui.faceUpHitboxes = {}
     ui.faceDownRect = nil
 end
 
---- Card rendering ---------------------------------------------------------------
+--- Card rendering ----------------------------------------------------------------
 function ui.drawCard(card, x, y, opts)
     opts = opts or {}
     x, y = math.floor(x), math.floor(y)
-    local w, h = ui.cardW, ui.cardH
+
+    local targetH = math.floor(opts.height or ui.cardH)
+    if targetH < 1 then targetH = 1 end
+    local image
+    if opts.back or not card or not card.afbeelding then
+        image = cardBack
+    else
+        image = card.afbeelding
+    end
+
+    local scale = targetH / image:getHeight()
+    local targetW = math.floor(image:getWidth() * scale + 0.5)
 
     love.graphics.setColor(1, 1, 1, opts.dimmed and 0.4 or 1)
-    if opts.back or not card or not card.afbeelding then
-        local scale = h / cardBack:getHeight()
-        love.graphics.draw(cardBack, x, y, 0, scale, scale)
-    else
-        local scale = h / card.afbeelding:getHeight()
-        love.graphics.draw(card.afbeelding, x, y, 0, scale, scale)
-    end
+    love.graphics.draw(image, x, y, 0, scale, scale)
 
     if opts.selected then
         love.graphics.setColor(0.96, 0.78, 0.28, 0.95)
         love.graphics.setLineWidth(math.max(2, math.floor(3 * ui.scale)))
-        love.graphics.rectangle("line", x, y, w, h, math.floor(14 * ui.scale), math.floor(14 * ui.scale))
+        love.graphics.rectangle("line", x, y, targetW, targetH, math.floor(14 * ui.scale), math.floor(14 * ui.scale))
         love.graphics.setLineWidth(1)
     end
     love.graphics.setColor(1, 1, 1, 1)
 end
 
---- HUD rendering ----------------------------------------------------------------
-local function drawHUDLeftTop(game)
-    local area = ui.areas.hudLeftTop
+--- HUD rendering -----------------------------------------------------------------
+local function drawInfoPanel(game, hint, statusLines)
+    local area = ui.areas.infoPanel
     if not area or area.w <= 0 or area.h <= 0 then return end
 
-    drawPanelBackground(area, 0.12)
+    drawPanelBackground(area, 0.16)
+    scissorRect(area)
 
     love.graphics.setFont(ui.fontBig)
     love.graphics.setColor(1, 1, 1, 0.92)
-    love.graphics.printf(string.format("Ronde %d", game.ronde or 1), area.x + ui.pad, area.y + ui.pad * 0.6, area.w - ui.pad * 2, "left")
+    love.graphics.printf("Info", area.x + ui.pad, area.y + ui.pad * 0.4, area.w - ui.pad * 2, "left")
 
-    local turnText
     local turnId = game.currentPlayer or 1
-    if turnId == localPlayerId() then
-        turnText = "Jij bent aan zet"
-    else
-        turnText = string.format("Speler %d is aan zet", turnId)
-    end
-
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.75)
-    love.graphics.printf(turnText, area.x + ui.pad, area.y + ui.pad + ui.fontBig:getHeight() * 0.7, area.w - ui.pad * 2, "left")
-
-    local phase = phaseLabel(game.state)
-    love.graphics.printf(phase, area.x + ui.pad, area.y + ui.pad + ui.fontBig:getHeight() * 0.7 + ui.fontSmall:getHeight() + ui.pad * 0.4, area.w - ui.pad * 2, "left")
-
-    love.graphics.setColor(1, 1, 1, 1)
-end
-
-local function drawHUDRightTop(game)
-    local area = ui.areas.hudRightTop
-    if not area or area.w <= 0 or area.h <= 0 then return end
-
-    drawPanelBackground(area, 0.12)
+    local turnText = (turnId == localPlayerId()) and "Jij bent aan zet" or string.format("Speler %d is aan zet", turnId)
+    local phaseText = "Fase: " .. phaseLabel(game.state)
 
     local mode
     if net.isMultiplayer() then
-        mode = net.isHost() and "Host" or "Client"
+        mode = net.isHost() and "Netwerk: Host" or "Netwerk: Client"
     else
-        mode = "Singleplayer"
+        mode = "Netwerk: Singleplayer"
     end
 
-    love.graphics.setFont(ui.fontBig)
-    love.graphics.setColor(1, 1, 1, 0.9)
-    love.graphics.printf(mode, area.x + ui.pad, area.y + ui.pad * 0.6, area.w - ui.pad * 2, "right")
+    local lines = {
+        string.format("Ronde %d", game.ronde or 1),
+        turnText,
+        phaseText,
+        "",
+        "Hint: " .. hint,
+        "",
+        mode,
+    }
+
+    if statusLines and #statusLines > 0 then
+        for _, line in ipairs(statusLines) do
+            table.insert(lines, line)
+        end
+    end
 
     love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.72)
+    love.graphics.setColor(1, 1, 1, 0.82)
 
-    if net.isMultiplayer() then
-        local id = net.localId or 1
-        love.graphics.printf(string.format("Speler %d / %d", id, game.maxPlayers or 2), area.x + ui.pad, area.y + ui.pad + ui.fontBig:getHeight() * 0.7, area.w - ui.pad * 2, "right")
-        love.graphics.printf("Verbinding actief", area.x + ui.pad, area.y + ui.pad + ui.fontBig:getHeight() * 0.7 + ui.fontSmall:getHeight() + ui.pad * 0.4, area.w - ui.pad * 2, "right")
-    else
-        love.graphics.printf("Speel tegen de AI", area.x + ui.pad, area.y + ui.pad + ui.fontBig:getHeight() * 0.7, area.w - ui.pad * 2, "right")
-        love.graphics.printf("Kaarten in deck: " .. tostring(drawPileModule.count()), area.x + ui.pad, area.y + ui.pad + ui.fontBig:getHeight() * 0.7 + ui.fontSmall:getHeight() + ui.pad * 0.4, area.w - ui.pad * 2, "right")
+    local width = area.w - ui.pad * 2
+    local y = area.y + ui.pad * 0.4 + ui.fontBig:getHeight() + ui.pad * 0.6
+    local lineHeight = ui.fontSmall:getHeight()
+
+    for _, text in ipairs(lines) do
+        if text == "" then
+            y = y + lineHeight * 0.6
+        else
+            local wrapped = select(1, ui.fontSmall:getWrap(text, width))
+            for _, row in ipairs(wrapped) do
+                love.graphics.printf(row, area.x + ui.pad, y, width, "left")
+                y = y + lineHeight
+            end
+            y = y + ui.pad * 0.2
+        end
+        if y > area.y + area.h - lineHeight then
+            break
+        end
     end
 
     love.graphics.setColor(1, 1, 1, 1)
+    clearScissor()
 end
 
 --- Buttons ----------------------------------------------------------------------
@@ -467,109 +581,94 @@ local function buttonEnabledStates(game)
     return states, playable
 end
 
-local function drawButton(id, label, rect, enabled)
-    rect.x, rect.y, rect.w, rect.h = math.floor(rect.x), math.floor(rect.y), math.floor(rect.w), math.floor(rect.h)
+function ui.button(x, y, w, h, label, enabled, id)
+    x, y, w, h = math.floor(x), math.floor(y), math.floor(w), math.floor(h)
     local pointer = ui.pointer
-    local hovered = pointer.x >= rect.x and pointer.x <= rect.x + rect.w and pointer.y >= rect.y and pointer.y <= rect.y + rect.h
+    local hovered = pointer.x >= x and pointer.x <= x + w and pointer.y >= y and pointer.y <= y + h
     local active = ui.buttons.active == id
 
-    local baseColor = enabled and {0.14, 0.33, 0.24} or {0.18, 0.18, 0.18}
-    local hoverBoost = hovered and enabled and 0.12 or 0
-    local r = clamp01(baseColor[1] + hoverBoost)
-    local g = clamp01(baseColor[2] + hoverBoost)
-    local b = clamp01(baseColor[3] + hoverBoost)
-    love.graphics.setColor(r, g, b, enabled and 0.9 or 0.45)
-    love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, math.floor(16 * ui.scale), math.floor(16 * ui.scale))
-    love.graphics.setColor(1, 1, 1, active and 0.9 or (enabled and 0.85 or 0.4))
+    local palettes = {
+        draw = {0.78, 0.2, 0.2},
+        play = {0.16, 0.55, 0.32},
+        pass = {0.95, 0.75, 0.25},
+    }
+    local baseColor = palettes[id] or {0.18, 0.33, 0.5}
+    if not enabled then
+        love.graphics.setColor(baseColor[1], baseColor[2], baseColor[3], 0.25)
+    elseif hovered then
+        love.graphics.setColor(clamp01(baseColor[1] + 0.12), clamp01(baseColor[2] + 0.12), clamp01(baseColor[3] + 0.12), 0.95)
+    else
+        love.graphics.setColor(baseColor[1], baseColor[2], baseColor[3], 0.85)
+    end
+
+    local radius = math.floor(16 * ui.scale)
+    love.graphics.rectangle("fill", x, y, w, h, radius, radius)
+
     love.graphics.setFont(ui.fontBig)
-    love.graphics.printf(label, rect.x + 6, rect.y + (rect.h - ui.fontBig:getHeight()) / 2, rect.w - 12, "center")
+    love.graphics.setColor(1, 1, 1, active and 0.95 or (enabled and 0.88 or 0.45))
+    love.graphics.printf(label, x + 6, y + (h - ui.fontBig:getHeight()) / 2, w - 12, "center")
     love.graphics.setColor(1, 1, 1, 1)
 
-    ui.buttons[id] = { x = rect.x, y = rect.y, w = rect.w, h = rect.h, enabled = enabled }
-end
-
-local function drawButtonsColumn(area, states)
-    local labels = {
-        play = "Speel",
-        draw = "Pakken",
-        pass = "Pas",
-    }
-
-    local buttonH = math.max(ui.minTap, math.floor(ui.fontBig:getHeight() + ui.pad))
-    local totalH = buttonH * 3 + ui.pad * 2
-    local startY = math.max(area.y, area.y + (area.h - totalH) / 2)
-    local width = math.max(ui.minTap * 2, area.w - ui.pad * 2)
-    local x = area.x + (area.w - width) / 2
-
-    for index, id in ipairs({"play", "draw", "pass"}) do
-        local rect = {
-            x = x,
-            y = startY + (index - 1) * (buttonH + ui.pad),
-            w = width,
-            h = buttonH,
-        }
-        drawButton(id, labels[id], rect, states[id])
-    end
+    ui.buttons[id] = { x = x, y = y, w = w, h = h, enabled = enabled, label = label }
 end
 
 local function drawButtonsRow(area, states)
     local labels = {
         play = "Speel",
-        draw = "Pakken",
+        draw = "Pak",
         pass = "Pas",
     }
 
-    local count = 3
-    local gap = ui.pad
-    local usableW = area.w - ui.pad * 2 - gap * (count - 1)
-    local width = math.max(ui.minTap * 1.8, usableW / count)
-    local totalW = width * count + gap * (count - 1)
+    local buttonH = math.max(ui.minTap, area.h - ui.pad * 0.4)
+    local gap = math.max(math.floor(ui.pad * 0.6), 8)
+    local usableW = area.w - ui.pad * 2
+    local width = math.max(ui.minTap * 1.6, math.floor((usableW - gap * 2) / 3))
+    local totalW = width * 3 + gap * 2
     local startX = area.x + (area.w - totalW) / 2
-    local height = math.max(ui.minTap, area.h)
+    local y = area.y + (area.h - buttonH) / 2
 
     for index, id in ipairs({"play", "draw", "pass"}) do
-        local rect = {
-            x = startX + (index - 1) * (width + gap),
-            y = area.y,
-            w = width,
-            h = height,
-        }
-        drawButton(id, labels[id], rect, states[id])
+        local rectX = startX + (index - 1) * (width + gap)
+        ui.button(rectX, y, width, buttonH, labels[id], states[id], id)
     end
+
+    ui.centerLayout.buttons = {
+        x = area.x,
+        y = area.y,
+        w = area.w,
+        h = area.h,
+    }
 end
 
---- Center area -----------------------------------------------------------------
+--- Center area ------------------------------------------------------------------
 local function drawDrawPile(layout, count)
     if not layout then return end
-    local x = layout.x
-    local y = layout.y
+    local size = ui.cardSizes.deck or ui.cardSizes.hand or { w = ui.cardW, h = ui.cardH }
     local layers = math.min(4, count)
     for i = layers, 1, -1 do
-        local offset = (i - 1) * math.floor(ui.scale * 4)
-        local alpha = 0.25 + 0.15 * i
-        love.graphics.setColor(1, 1, 1, alpha)
-        ui.drawCard(nil, x + offset, y - offset, { back = true })
+        local offset = (i - 1) * math.max(1, math.floor(ui.scale * 3))
+        love.graphics.setColor(1, 1, 1, 0.25 + 0.15 * i)
+        ui.drawCard(nil, layout.x + offset, layout.y - offset, { back = true, height = size.h })
     end
-    love.graphics.setColor(1, 1, 1, 0.75)
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.printf(string.format("Deck: %d", count), x - ui.pad, y + ui.cardH + ui.pad * 0.3, ui.cardW + ui.pad * 2, "center")
     love.graphics.setColor(1, 1, 1, 1)
 end
 
 local function drawPot(layout, pot)
     if not layout then return end
+    local size = ui.cardSizes.deck or ui.cardSizes.hand or { w = ui.cardW, h = ui.cardH }
     local top = pot[#pot]
     local prev = pot[#pot - 1]
 
     if prev and prev.afbeelding then
         love.graphics.setColor(1, 1, 1, 0.4)
-        ui.drawCard(prev, layout.x - math.floor(ui.pad * 0.3), layout.y + math.floor(ui.pad * 0.3))
+        ui.drawCard(prev, layout.x - math.floor(ui.pad * 0.3), layout.y + math.floor(ui.pad * 0.3), { height = size.h })
     end
+
     love.graphics.setColor(1, 1, 1, 1)
     if top then
-        ui.drawCard(top, layout.x, layout.y)
+        ui.drawCard(top, layout.x, layout.y, { height = size.h })
     else
-        ui.drawCard(nil, layout.x, layout.y, { back = true, dimmed = true })
+        ui.drawCard(nil, layout.x, layout.y, { back = true, dimmed = true, height = size.h })
     end
 end
 
@@ -578,49 +677,41 @@ local function drawCenterArea(game)
     if not area or area.w <= 0 or area.h <= 0 then return end
 
     drawPanelBackground(area, 0.16)
+    scissorRect(area)
 
-    local states, playable = buttonEnabledStates(game)
     local drawCount = drawPileModule.count()
-
-    if ui.compact then
-        local cardY = area.y + math.max(ui.pad, (area.h - ui.cardH - ui.minTap - ui.pad * 2) / 2)
-        local drawX = clamp(area.x, area.x + area.w * 0.25 - ui.cardW / 2, area.x + area.w - ui.cardW)
-        local potX  = clamp(area.x, area.x + area.w * 0.5 - ui.cardW / 2, area.x + area.w - ui.cardW)
-        local drawLayout = { x = drawX, y = cardY }
-        local potLayout  = { x = potX, y = cardY }
-        drawDrawPile(drawLayout, drawCount)
-        drawPot(potLayout, game.pot)
-
-        local rowHeight = math.max(ui.minTap, math.floor(ui.fontBig:getHeight() + ui.pad))
-        local rowY = area.y + area.h - rowHeight - ui.pad
-        drawButtonsRow({ x = area.x, y = rowY, w = area.w, h = rowHeight }, states)
-        ui.centerLayout.draw = { x = drawLayout.x, y = drawLayout.y, w = ui.cardW, h = ui.cardH }
-        ui.centerLayout.pot = { x = potLayout.x, y = potLayout.y, w = ui.cardW, h = ui.cardH }
-        ui.centerLayout.buttons = { x = area.x, y = rowY, w = area.w, h = rowHeight }
-    else
-        local colW = math.floor(area.w / 3)
-        local cardY = area.y + (area.h - ui.cardH) / 2
-
-        local drawLayout = { x = area.x + (colW - ui.cardW) / 2, y = cardY }
-        local potLayout  = { x = area.x + colW + (colW - ui.cardW) / 2, y = cardY }
-        local buttonsArea = { x = area.x + colW * 2, y = area.y, w = area.w - colW * 2, h = area.h }
-
-        drawDrawPile(drawLayout, drawCount)
-        drawPot(potLayout, game.pot)
-        drawButtonsColumn(buttonsArea, states)
-
-        ui.centerLayout.draw = { x = drawLayout.x, y = drawLayout.y, w = ui.cardW, h = ui.cardH }
-        ui.centerLayout.pot = { x = potLayout.x, y = potLayout.y, w = ui.cardW, h = ui.cardH }
-        ui.centerLayout.buttons = buttonsArea
+    local size = ui.cardSizes.deck or ui.cardSizes.hand or { w = ui.cardW, h = ui.cardH }
+    local gap = math.max(math.floor(ui.pad), math.floor((area.w - size.w * 2) / 3))
+    if gap < math.floor(ui.pad * 0.4) then
+        gap = math.floor(ui.pad * 0.4)
+    end
+    local totalW = size.w * 2 + gap
+    if totalW > area.w then
+        gap = math.max(math.floor(ui.pad * 0.2), 4)
+        totalW = size.w * 2 + gap
     end
 
+    local startX = area.x + (area.w - totalW) / 2
+    local cardY = area.y + math.max(ui.pad, (area.h - size.h - ui.fontSmall:getHeight() - ui.pad * 2) / 2)
+    cardY = math.floor(cardY + 0.5)
+
+    local drawLayout = { x = math.floor(startX + 0.5), y = cardY }
+    local potLayout = { x = math.floor(startX + size.w + gap + 0.5), y = cardY }
+
+    drawDrawPile(drawLayout, drawCount)
+    drawPot(potLayout, game.pot)
+
     love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.72)
-    local hint = hintText(game, isMyTurn(game), playable)
-    love.graphics.printf(hint, area.x + ui.pad, area.y + area.h - ui.fontSmall:getHeight() - ui.pad * 0.6, area.w - ui.pad * 2, "center")
+    love.graphics.setColor(1, 1, 1, 0.82)
+    local labelY = cardY + size.h + ui.pad * 0.4
+    love.graphics.printf(string.format("Deck: %d", drawCount), drawLayout.x - ui.pad, labelY, size.w + ui.pad * 2, "center")
+    love.graphics.printf(string.format("Pot: %d", #game.pot), potLayout.x - ui.pad, labelY, size.w + ui.pad * 2, "center")
     love.graphics.setColor(1, 1, 1, 1)
 
-    ui.centerLayout.hint = hint
+    clearScissor()
+
+    ui.centerLayout.draw = { x = drawLayout.x, y = cardY, w = size.w, h = size.h }
+    ui.centerLayout.pot = { x = potLayout.x, y = cardY, w = size.w, h = size.h }
 end
 
 local function drawPotOverlay(game)
@@ -648,24 +739,20 @@ local function drawPotOverlay(game)
     love.graphics.setColor(1, 1, 1, 0.9)
     love.graphics.printf("Pot kaarten", x + ui.pad, y + ui.pad, overlayW - ui.pad * 2, "center")
 
-    local cardsPerRow = math.max(1, math.floor((overlayW - ui.pad * 2) / (ui.cardW * 0.75)))
-    local scale = 0.75
-    local scaledH = ui.cardH * scale
-    local scaledW = ui.cardW * scale
+    local cardsPerRow = math.max(1, math.floor((overlayW - ui.pad * 2) / (ui.cardW * 0.9)))
+    local scaleH = math.max(math.floor(ui.cardH * 0.85), math.floor(ui.minTap * 1.2))
     local gap = ui.pad * 0.5
     local startY = y + ui.pad * 2 + ui.fontBig:getHeight()
     local pot = game.pot
+
     for index = #pot, 1, -1 do
         local card = pot[index]
-        local row = math.floor((#pot - index) / cardsPerRow)
-        local col = (#pot - index) % cardsPerRow
-        local rowY = startY + row * (scaledH + gap)
-        local colX = x + ui.pad + col * (scaledW + gap)
-        love.graphics.push()
-        love.graphics.translate(colX, rowY)
-        love.graphics.scale(scale, scale)
-        ui.drawCard(card, 0, 0)
-        love.graphics.pop()
+        local pos = #pot - index
+        local row = math.floor(pos / cardsPerRow)
+        local col = pos % cardsPerRow
+        local drawX = x + ui.pad + col * (ui.cardW + gap)
+        local drawY = startY + row * (scaleH + gap)
+        ui.drawCard(card, drawX, drawY, { height = scaleH })
     end
 
     love.graphics.setFont(ui.fontSmall)
@@ -675,67 +762,70 @@ local function drawPotOverlay(game)
 end
 
 --- Hand drawing -----------------------------------------------------------------
-local function drawFaceDownRow(pData, startY)
-    local rect = ui.areas.handBottom
-    local faceDown = pData.faceDown or {}
-    if #faceDown == 0 then
-        ui.faceDownRect = nil
-        return startY
-    end
-
-    local scale = 0.65
-    local h = math.floor(ui.cardH * scale)
-    local w = math.floor(ui.cardW * scale)
-    local gap = math.floor(ui.pad * 0.4)
-    local stride = math.floor(w * 0.6) + gap
-    local totalW = w + math.max(0, (#faceDown - 1)) * stride
-    local xStart = rect.x + (rect.w - totalW) / 2
-
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.65)
-    love.graphics.printf("Blinde stapel", rect.x, startY - ui.fontSmall:getHeight() - ui.pad * 0.2, rect.w, "center")
-    love.graphics.setColor(1, 1, 1, 1)
-
-    local scaleImg = h / cardBack:getHeight()
-    for i = 1, #faceDown do
-        local x = xStart + (i - 1) * stride
-        love.graphics.draw(cardBack, math.floor(x), math.floor(startY), 0, scaleImg, scaleImg)
-
-    end
-    local maxScroll = math.max(0, (#cards * step + ui.pad) - rect.w)
-    if pData.scrollOffset > maxScroll then pData.scrollOffset = maxScroll end
-    if pData.scrollOffset < 0 then pData.scrollOffset = 0 end
-
-    ui.faceDownRect = { x = xStart, y = startY, w = totalW, h = h }
-    return startY + h + ui.pad
-end
-
-local function drawFaceUpRow(pData, startY)
-    local rect = ui.areas.handBottom
-    local faceUp = pData.faceUp or {}
+local function drawBottomStacks(pData)
+    local area = ui.areas.faceBottom
     ui.faceUpHitboxes = {}
-    if #faceUp == 0 then
-        return startY
-    end
+    ui.faceDownRect = nil
+
+    if not area or area.w <= 0 or area.h <= 0 then return end
+
+    drawPanelBackground(area, 0.16)
+    scissorRect(area)
+
+    local faceDown = pData.faceDown or {}
+    local faceUp = pData.faceUp or {}
+    local downSize = ui.cardSizes.faceDown or { w = math.floor(ui.cardW * 0.65), h = math.floor(ui.cardH * 0.65) }
+    local openSize = ui.cardSizes.open or { w = math.floor(ui.cardW * 0.85), h = math.floor(ui.cardH * 0.85) }
+    local width = area.w - ui.pad * 2
+    local labelHeight = ui.fontSmall:getHeight()
+
+    local downCount = math.min(#faceDown, 3)
+    local downGap = downCount > 1 and math.min(downSize.w * 0.6, (width - downSize.w) / (downCount - 1)) or 0
+    local downTotal = downCount > 0 and (downSize.w + (downCount - 1) * downGap) or downSize.w
+    local downX = area.x + (area.w - downTotal) / 2
+    local downY = area.y + area.h - downSize.h - ui.pad
 
     love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.65)
-    love.graphics.printf("Open kaarten", rect.x + ui.pad, startY, rect.w - ui.pad * 2, "left")
+    love.graphics.setColor(1, 1, 1, 0.75)
+    love.graphics.printf("Dichte kaarten", area.x + ui.pad, downY - labelHeight - ui.pad * 0.2, area.w - ui.pad * 2, "left")
     love.graphics.setColor(1, 1, 1, 1)
 
-    local rowY = startY + ui.fontSmall:getHeight() + ui.pad * 0.2
-    local gap = math.floor(ui.pad * 0.4)
-    local stride = ui.cardW + gap
-    local totalW = ui.cardW + math.max(0, (#faceUp - 1)) * stride
-    local xStart = rect.x + (rect.w - totalW) / 2
-
-    for index, card in ipairs(faceUp) do
-        local x = xStart + (index - 1) * stride
-        ui.drawCard(card, x, rowY, { selected = card.selected })
-        ui.faceUpHitboxes[index] = { x = x, y = rowY, w = ui.cardW, h = ui.cardH }
+    if downCount > 0 then
+        for i = 1, downCount do
+            local x = downX + (i - 1) * downGap
+            ui.drawCard(nil, x, downY, { back = true, height = downSize.h })
+        end
+        ui.faceDownRect = { x = downX, y = downY, w = downTotal, h = downSize.h }
+    else
+        love.graphics.setColor(1, 1, 1, 0.5)
+        love.graphics.printf("Geen dichte kaarten", area.x + ui.pad, downY + downSize.h / 2 - labelHeight / 2, area.w - ui.pad * 2, "left")
+        love.graphics.setColor(1, 1, 1, 1)
     end
 
-    return rowY + ui.cardH + ui.pad
+    local openCount = #faceUp
+    local openGap = openCount > 1 and math.min(openSize.w * 0.6, (width - openSize.w) / (openCount - 1)) or 0
+    local openTotal = openCount > 0 and (openSize.w + (openCount - 1) * openGap) or openSize.w
+    local openX = area.x + (area.w - openTotal) / 2
+    local openY = downY - openSize.h - math.floor(ui.pad * 0.6)
+
+    love.graphics.setFont(ui.fontSmall)
+    love.graphics.setColor(1, 1, 1, 0.75)
+    love.graphics.printf("Open kaarten", area.x + ui.pad, openY - labelHeight - ui.pad * 0.2, area.w - ui.pad * 2, "left")
+    love.graphics.setColor(1, 1, 1, 1)
+
+    if openCount == 0 then
+        love.graphics.setColor(1, 1, 1, 0.5)
+        love.graphics.printf("Geen open kaarten", area.x + ui.pad, openY + openSize.h / 2 - labelHeight / 2, area.w - ui.pad * 2, "left")
+        love.graphics.setColor(1, 1, 1, 1)
+    else
+        for index, card in ipairs(faceUp) do
+            local x = openX + (index - 1) * openGap
+            ui.drawCard(card, x, openY, { height = openSize.h, selected = card.selected })
+            ui.faceUpHitboxes[index] = { x = x, y = openY, w = openSize.w, h = openSize.h }
+        end
+    end
+
+    clearScissor()
 end
 
 local function drawOverflowIndicators(rect, view)
@@ -751,52 +841,54 @@ local function drawHandBottom(game, pData)
     if not rect or rect.w <= 0 or rect.h <= 0 then return end
 
     drawPanelBackground(rect, 0.18)
+    scissorRect(rect)
 
     love.graphics.setFont(ui.fontSmall)
     love.graphics.setColor(1, 1, 1, 0.85)
     love.graphics.printf("Jouw hand", rect.x + ui.pad, rect.y + ui.pad * 0.4, rect.w - ui.pad * 2, "left")
     love.graphics.setColor(1, 1, 1, 1)
 
-    local cursorY = rect.y + ui.pad * 1.4
-    cursorY = drawFaceDownRow(pData, cursorY)
-    cursorY = drawFaceUpRow(pData, cursorY)
-
-
     local view = computeHandView(pData)
-    if not view then return end
-    local baseline = math.max(cursorY, rect.y + rect.h - ui.cardH - ui.pad)
-    baseline = math.min(baseline, rect.y + rect.h - ui.cardH)
-    local lift = math.floor(ui.pad * 0.7)
+    if not view then
+        clearScissor()
+        return
+    end
 
-    scissorRect(rect)
+    local cardH = (ui.cardSizes.hand and ui.cardSizes.hand.h) or ui.cardH
+    local cardW = view.cardW or (ui.cardSizes.hand and ui.cardSizes.hand.w) or ui.cardW
+    local baseline = rect.y + rect.h - cardH - ui.pad
+    local lift = math.max(4, math.floor(cardH * 0.12))
+
     ui.handHitboxes = {}
     local selectedLater = {}
 
     for index, card in ipairs(pData.hand or {}) do
         local x = view.xStart + (index - 1) * view.step
         local hitW = view.hitW
-        local hitX = x - (hitW - ui.cardW) / 2
-        hitX = math.max(rect.x, math.min(hitX, rect.x + rect.w - hitW))
+        local hitX = x - (hitW - cardW) / 2
+        hitX = clamp(rect.x, hitX, rect.x + rect.w - hitW)
         local selected = card.selected
         local drawY = selected and (baseline - lift) or baseline
 
-        if x + ui.cardW > rect.x and x < rect.x + rect.w then
+        ui.handHitboxes[index] = { x = hitX, y = drawY, w = hitW, h = cardH + lift }
+
+        if x + cardW > rect.x and x < rect.x + rect.w then
             if selected then
                 table.insert(selectedLater, { card = card, x = x, y = drawY })
             else
-                ui.drawCard(card, x, drawY)
+                ui.drawCard(card, x, drawY, { height = cardH })
             end
         end
     end
 
-    for _, info in ipairs(selectedBuffer) do
-        ui.drawCard(info.card, info.x, info.y, { selected = true })
+    for _, info in ipairs(selectedLater) do
+        ui.drawCard(info.card, info.x, info.y, { height = cardH, selected = true })
     end
 
     drawOverflowIndicators(rect, view)
     clearScissor()
 
-    if not isMyTurn(ui.game) then
+    if not isMyTurn(game) then
         love.graphics.setColor(0, 0, 0, 0.18)
         love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 18, 18)
         love.graphics.setColor(1, 1, 1, 0.7)
@@ -805,241 +897,91 @@ local function drawHandBottom(game, pData)
     end
 end
 
-local function drawTopOpponent(opponent)
-    if not opponent then return end
-    local rect = ui.handRects.opponent
-    if not rect or rect.w <= 0 or rect.h <= 0 then return end
-
-    drawPanelBackground(rect, 0.75)
-
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.82)
-    love.graphics.print("Tegenstander", rect.x + ui.pad, rect.y + ui.pad * 0.6)
-
-    local cards = opponent.hand or {}
-    if #cards == 0 then
-        love.graphics.setColor(1, 1, 1, 0.6)
-        love.graphics.printf("Geen kaarten", rect.x, rect.y + rect.h / 2 - ui.fontSmall:getHeight() / 2, rect.w, "center")
-        love.graphics.setColor(1, 1, 1, 1)
-        return
-    end
-
-    scissorRect(rect)
-    local stride = math.max(1, math.floor((rect.w - 2 * ui.pad) / math.max(1, #cards)))
-    stride = math.min(stride, ui.cardW)
-    local totalW = ui.cardW + math.max(0, (#cards - 1)) * stride
-    local startX = rect.x + (rect.w - totalW) / 2
-    local y = rect.y + rect.h / 2 - ui.cardH / 2
-    local scaleImg = ui.cardH / cardBack:getHeight()
-
-    for i = 1, #cards do
-        local x = startX + (i - 1) * stride
-        love.graphics.setColor(1, 1, 1, 0.85)
-        love.graphics.draw(cardBack, math.floor(x), math.floor(y), 0, scaleImg, scaleImg)
-    end
-    clearScissor()
-    love.graphics.setColor(1, 1, 1, 1)
-end
-
-local function drawPileStack(drawPile, x, y)
-    local count = drawPile and drawPile.count and drawPile.count() or 0
-    local layers = math.min(4, count)
-    local scale = ui.cardH / cardBack:getHeight()
-    for i = 1, layers do
-        love.graphics.setColor(1, 1, 1, 0.25 + 0.15 * (i - 1))
-        love.graphics.draw(cardBack, x - (i - 1) * ui.scale * 4, y - (i - 1) * ui.scale * 3, 0, scale, scale)
-    end
-    love.graphics.setColor(1, 1, 1, 0.8)
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.printf("Trekstapel\n" .. count, x - ui.cardW * 0.2, y + ui.cardH + ui.pad * 0.2, ui.cardW * 1.4, "center")
-    love.graphics.setColor(1, 1, 1, 1)
-end
-
-local function drawPot(pot, rect)
-    if not rect then return end
-    local x = rect.x
-    local y = rect.y
-    local top = pot[#pot]
-    local prev = pot[#pot - 1]
-
-    if prev and prev.afbeelding then
-        love.graphics.setColor(1, 1, 1, 0.4)
-        local scale = ui.cardH / prev.afbeelding:getHeight()
-        love.graphics.draw(prev.afbeelding, x - ui.pad * 0.3, y + ui.pad * 0.3, 0, scale, scale)
-    end
-
-    if top and top.afbeelding then
-        love.graphics.setColor(1, 1, 1, 1)
-        local scale = ui.cardH / top.afbeelding:getHeight()
-        love.graphics.draw(top.afbeelding, x, y, 0, scale, scale)
-    else
-        love.graphics.setColor(1, 1, 1, 0.2)
-        love.graphics.rectangle("line", x, y, ui.cardW, ui.cardH, 14, 14)
-    end
-
-    love.graphics.setColor(1, 1, 1, 0.8)
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.printf("Aflegstapel\n" .. #pot, x - ui.cardW * 0.1, y + ui.cardH + ui.pad * 0.2, ui.cardW * 1.2, "center")
-    love.graphics.setColor(1, 1, 1, 1)
-end
-
-function ui.button(x, y, w, h, label, enabled, id)
-    x, y, w, h = math.floor(x), math.floor(y), math.floor(w), math.floor(h)
-    local pointerX, pointerY = love.mouse.getPosition()
-    local hovered = utils.inside(pointerX, pointerY, x, y, w, h)
-    local radius = math.floor(12 * ui.scale)
-    local baseColor = {0.16, 0.41, 0.28}
-    if id == "play" then baseColor = {0.12, 0.46, 0.32} end
-    if not enabled then
-        love.graphics.setColor(baseColor[1], baseColor[2], baseColor[3], 0.25)
-    elseif hovered then
-        love.graphics.setColor(baseColor[1] + 0.08, baseColor[2] + 0.08, baseColor[3] + 0.08, 0.95)
-    else
-        love.graphics.setColor(baseColor[1], baseColor[2], baseColor[3], 0.85)
-    end
-    love.graphics.rectangle("fill", x, y, w, h, radius, radius)
-    love.graphics.setColor(1, 1, 1, enabled and 0.92 or 0.55)
-    love.graphics.setFont(ui.fontBig)
-    love.graphics.printf(label, x, y + (h - ui.fontBig:getHeight()) / 2, w, "center")
-    love.graphics.setColor(1, 1, 1, 1)
-
-    ui.buttons[id] = { x = x, y = y, w = w, h = h, enabled = enabled, label = label }
-end
-
-local function drawCenterArea(pot, drawPile, buttons)
-    local rect = ui.areas.center
-    if not rect then return end
-    drawPanelBackground(rect, 0.85)
-
-    scissorRect(rect)
-    local colW = math.floor(rect.w / 3)
-    local cardY = rect.y + (rect.h - ui.cardH) / 2
-    local minCardX = rect.x + ui.pad
-    local maxCardX = rect.x + rect.w - ui.cardW - ui.pad
-    if maxCardX < minCardX then maxCardX = minCardX end
-    local drawX = clamp(minCardX, rect.x + (colW - ui.cardW) / 2, maxCardX)
-    local potX = clamp(minCardX, rect.x + colW + (colW - ui.cardW) / 2, maxCardX)
-    local btnColX = rect.x + colW * 2 + ui.pad
-
-    ui.centerState.pot = { x = math.floor(potX), y = math.floor(cardY), w = ui.cardW, h = ui.cardH }
-    ui.centerState.draw = { x = math.floor(drawX), y = math.floor(cardY), w = ui.cardW, h = ui.cardH }
-
-    drawPileStack(drawPile, ui.centerState.draw.x, ui.centerState.draw.y)
-    drawPot(pot, ui.centerState.pot)
-
-    local buttonHeight = math.max(ui.minTap, math.floor(ui.fontBig:getHeight() + ui.pad * 1.1))
-    local maxWidth = math.floor(rect.w / 3 - ui.pad * 2)
-    local buttonWidth = math.max(ui.minTap * 2, math.min(maxWidth, math.floor(240 * ui.scale)))
-    local gap = ui.pad
-
-    if ui.compact then
-        local btnY = ui.centerState.pot.y + ui.cardH + ui.pad * 1.5
-        btnY = math.min(btnY, rect.y + rect.h - buttonHeight - ui.pad)
-        local totalW = #buttons * buttonWidth + math.max(0, #buttons - 1) * gap
-        local startX = rect.x + (rect.w - totalW) / 2
-        for i, btn in ipairs(buttons) do
-            local x = startX + (i - 1) * (buttonWidth + gap)
-            ui.button(x, btnY, buttonWidth, buttonHeight, btn.label, btn.enabled, btn.id)
-        end
-        ui.centerState.buttonRow = { x = math.floor(startX), y = math.floor(btnY), w = math.floor(totalW), h = buttonHeight }
-        ui.centerState.buttonColumn = nil
-    else
-        local totalH = #buttons * buttonHeight + math.max(0, #buttons - 1) * gap
-        local startY = rect.y + (rect.h - totalH) / 2
-        local maxBtnX = rect.x + rect.w - buttonWidth - ui.pad
-        if maxBtnX < rect.x + ui.pad then maxBtnX = rect.x + ui.pad end
-        local x = clamp(rect.x + ui.pad, btnColX, maxBtnX)
-        ui.centerState.buttonColumn = { x = math.floor(x), y = math.floor(startY), w = buttonWidth, h = totalH }
-        ui.centerState.buttonRow = nil
-        for i, btn in ipairs(buttons) do
-            local y = startY + (i - 1) * (buttonHeight + gap)
-            ui.button(x, y, buttonWidth, buttonHeight, btn.label, btn.enabled, btn.id)
-        end
-    end
-
-    clearScissor()
-
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.7)
-    love.graphics.printf("Dubbelklik/tap om te spelen", rect.x, rect.y + rect.h - ui.fontSmall:getHeight() - ui.pad, rect.w, "center")
-    love.graphics.setColor(1, 1, 1, 1)
-end
-
-        ui.handHitboxes[index] = {
-            x = hitX,
-            y = baseline,
-            w = hitW,
-            h = ui.cardH,
-            cardX = x,
-            cardY = drawY,
-        }
-    end
-
-    for _, data in ipairs(selectedLater) do
-        ui.drawCard(data.card, data.x, data.y, { selected = true })
-    end
-
-    drawOverflowIndicators(rect, view)
-    clearScissor()
-
-    if not isMyTurn(game) then
-        love.graphics.setColor(0, 0, 0, 0.2)
-        love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 18, 18)
-        love.graphics.setColor(1, 1, 1, 0.7)
-        love.graphics.printf("Wachten op tegenstander", rect.x, rect.y + rect.h - ui.fontSmall:getHeight() - ui.pad, rect.w, "center")
-        love.graphics.setColor(1, 1, 1, 1)
-    end
-end
-
---- Opponent --------------------------------------------------------------------
-local function drawTopOpponent(opponent)
-    local rect = ui.areas.topOpponent
-    if not rect or rect.h <= 0 or rect.w <= 0 then return end
-
-    drawPanelBackground(rect, 0.12)
-    love.graphics.setFont(ui.fontSmall)
-    love.graphics.setColor(1, 1, 1, 0.82)
-    love.graphics.printf("Tegenstander", rect.x + ui.pad, rect.y + ui.pad * 0.4, rect.w - ui.pad * 2, "left")
-    love.graphics.setColor(1, 1, 1, 1)
-
-    local cards = opponent and opponent.hand or {}
-    if not cards or #cards == 0 then
-        love.graphics.setColor(1, 1, 1, 0.6)
-        love.graphics.printf("Geen kaarten", rect.x, rect.y + rect.h / 2 - ui.fontSmall:getHeight() / 2, rect.w, "center")
-        love.graphics.setColor(1, 1, 1, 1)
-        return
-    end
-
-    scissorRect(rect)
-    local stride = math.max(1, math.floor((rect.w - ui.pad * 2) / math.max(1, #cards)))
-    stride = math.min(stride, ui.cardW)
-    local totalW = ui.cardW + math.max(0, (#cards - 1)) * stride
-    local startX = rect.x + (rect.w - totalW) / 2
-    local y = rect.y + rect.h / 2 - ui.cardH / 2
-
-    for i = 1, #cards do
-        local x = startX + (i - 1) * stride
-        ui.drawCard(nil, x, y, { back = true })
-    end
-    clearScissor()
-
-    love.graphics.setColor(1, 1, 1, 0.7)
-    love.graphics.printf(string.format("%d kaarten", #cards), rect.x, rect.y + rect.h - ui.fontSmall:getHeight() - ui.pad, rect.w, "center")
-    love.graphics.setColor(1, 1, 1, 1)
-end
-
---- Status bar ------------------------------------------------------------------
-local function drawStatusBar(lines)
-    local rect = ui.areas.statusBottom
+local function drawOpponentHand(opponent)
+    local rect = ui.areas.opponentHand
     if not rect or rect.w <= 0 or rect.h <= 0 then return end
 
     drawPanelBackground(rect, 0.14)
+    scissorRect(rect)
+
     love.graphics.setFont(ui.fontSmall)
     love.graphics.setColor(1, 1, 1, 0.82)
-
-    local text = table.concat(lines, "  •  ")
-    love.graphics.printf(text, rect.x + ui.pad, rect.y + (rect.h - ui.fontSmall:getHeight()) / 2, rect.w - ui.pad * 2, "center")
+    love.graphics.printf("Hand tegenstander", rect.x + ui.pad, rect.y + ui.pad * 0.4, rect.w - ui.pad * 2, "left")
     love.graphics.setColor(1, 1, 1, 1)
+
+    local cards = opponent and opponent.hand or {}
+    local count = #cards
+    local size = ui.cardSizes.opponent or ui.cardSizes.deck or { w = ui.cardW, h = ui.cardH }
+    local available = rect.w - ui.pad * 2
+    local stride = count > 1 and math.min(size.w * 0.7, (available - size.w) / (count - 1)) or 0
+    local totalW = size.w + math.max(0, (count - 1) * stride)
+    local startX = rect.x + (rect.w - totalW) / 2
+    local cardY = rect.y + ui.fontSmall:getHeight() + ui.pad * 1.1
+    if cardY + size.h > rect.y + rect.h - ui.pad then
+        cardY = rect.y + rect.h - size.h - ui.pad
+    end
+
+    if count == 0 then
+        love.graphics.setColor(1, 1, 1, 0.6)
+        love.graphics.printf("Geen kaarten", rect.x, rect.y + rect.h / 2 - ui.fontSmall:getHeight() / 2, rect.w, "center")
+        love.graphics.setColor(1, 1, 1, 1)
+    else
+        for i = 1, count do
+            local x = startX + (i - 1) * stride
+            ui.drawCard(nil, x, cardY, { back = true, height = size.h })
+        end
+        love.graphics.setColor(1, 1, 1, 0.68)
+        love.graphics.printf(string.format("%d kaarten", count), rect.x, rect.y + rect.h - ui.fontSmall:getHeight() - ui.pad * 0.6, rect.w, "center")
+        love.graphics.setColor(1, 1, 1, 1)
+    end
+
+    clearScissor()
+end
+
+local function drawOpponentFaceDown(opponent)
+    local rect = ui.areas.opponentFaceDown
+    if not rect or rect.w <= 0 or rect.h <= 0 then return end
+
+    drawPanelBackground(rect, 0.12)
+    scissorRect(rect)
+
+    love.graphics.setFont(ui.fontSmall)
+    love.graphics.setColor(1, 1, 1, 0.78)
+    love.graphics.printf("Dichte kaarten", rect.x + ui.pad, rect.y + ui.pad * 0.4, rect.w - ui.pad * 2, "left")
+    love.graphics.setColor(1, 1, 1, 1)
+
+    local deck = opponent and opponent.faceDown or {}
+    local count = math.min(#deck, 3)
+    local size = ui.cardSizes.faceDown or { w = math.floor(ui.cardW * 0.65), h = math.floor(ui.cardH * 0.65) }
+    local available = rect.w - ui.pad * 2
+    local gap = count > 1 and math.min(size.w * 0.6, (available - size.w) / (count - 1)) or 0
+    local totalW = count > 0 and (size.w + (count - 1) * gap) or size.w
+    local startX = rect.x + (rect.w - totalW) / 2
+    local cardY = rect.y + ui.fontSmall:getHeight() + ui.pad
+    if cardY + size.h > rect.y + rect.h - ui.pad then
+        cardY = rect.y + rect.h - size.h - ui.pad
+    end
+
+    if count == 0 then
+        love.graphics.setColor(1, 1, 1, 0.5)
+        love.graphics.printf("Geen dichte kaarten", rect.x, rect.y + rect.h / 2 - ui.fontSmall:getHeight() / 2, rect.w, "center")
+        love.graphics.setColor(1, 1, 1, 1)
+    else
+        for i = 1, count do
+            local x = startX + (i - 1) * gap
+            ui.drawCard(nil, x, cardY, { back = true, height = size.h })
+        end
+        love.graphics.setColor(1, 1, 1, 0.65)
+        love.graphics.printf(string.format("%d totaal", #deck), rect.x, rect.y + rect.h - ui.fontSmall:getHeight() - ui.pad * 0.5, rect.w, "center")
+        love.graphics.setColor(1, 1, 1, 1)
+    end
+
+    clearScissor()
+end
+
+local function drawTopOpponent(opponent)
+    drawOpponentHand(opponent)
+    drawOpponentFaceDown(opponent)
 end
 
 --- Debug overlay ----------------------------------------------------------------
@@ -1059,22 +1001,39 @@ end
 function ui.draw(game, drawPile)
     ui.game = game
     local me = currentPlayerData()
-    local opponent = player.players[localPlayerId() == 1 and 2 or 1]
+    local opponent
+    if localPlayerId() == 1 then
+        opponent = player.players[2]
+    else
+        opponent = player.players[1]
+    end
     local turn = isMyTurn(game)
 
-    drawHUDLeftTop(game)
-    drawHUDRightTop(game)
-    drawCenterArea(game)
-    drawTopOpponent(opponent)
-    drawHandBottom(game, me)
-
+    local states, playable = buttonEnabledStates(game)
+    local hint = hintText(game, turn, playable)
     local status = formatStatusLines(game, turn)
-    drawStatusBar(status)
+
+    drawInfoPanel(game, hint, status)
+    drawTopOpponent(opponent)
+    drawCenterArea(game)
+    if me then
+        drawBottomStacks(me)
+        drawHandBottom(game, me)
+    else
+        ui.faceUpHitboxes = {}
+        ui.faceDownRect = nil
+    end
+
+    local buttonsArea = ui.areas.buttons
+    if buttonsArea and buttonsArea.w > 0 and buttonsArea.h > 0 then
+        drawButtonsRow(buttonsArea, states)
+    end
+
     drawPotOverlay(game)
     drawDebugOverlay()
 end
 
---- Interaction helpers ---------------------------------------------------------
+--- Interaction helpers ----------------------------------------------------------
 local function triggerInvalid()
     if ui.game then
         ui.game.invalidTimer = 1.0
@@ -1142,7 +1101,7 @@ end
 
 local function handleButtonPress(x, y)
     for id, btn in pairs(ui.buttons) do
-        if type(btn) == "table" and btn.x and utils.inside(x, y, btn.x, btn.y, btn.w, btn.h) then
+        if type(id) == "string" and type(btn) == "table" and btn.x and utils.inside(x, y, btn.x, btn.y, btn.w, btn.h) then
             if btn.enabled then
                 ui.buttons.active = id
             else
@@ -1214,14 +1173,12 @@ local function handleBlindClick(x, y)
     if not ui.faceDownRect then return false end
     if not utils.inside(x, y, ui.faceDownRect.x, ui.faceDownRect.y, ui.faceDownRect.w, ui.faceDownRect.h + ui.cardH * 0.1) then
         return false
-
     end
-    return false
-end
 
     local stack = player.players[localPlayerId()].faceDown
     if #stack == 0 then return true end
     local card = table.remove(stack, 1)
+    ui.game.reveal = ui.game.reveal or {}
     ui.game.reveal.timer = 1.0
     ui.game.reveal.card = card
     ui.game.reveal.player = localPlayerId()
@@ -1234,7 +1191,7 @@ local function handleSetupOpenClick(x, y)
     if not pData then return false end
     for index = #ui.handHitboxes, 1, -1 do
         local hit = ui.handHitboxes[index]
-        if hit and utils.inside(x, y, hit.x, hit.y, hit.w, hit.h) then
+        if hit and utils.inside(x, y, hit.x, hit.y - ui.cardH * 0.1, hit.w, hit.h + ui.cardH * 0.2) then
             if #pData.faceUp >= config.SETUP_OPEN then
                 return true
             end
@@ -1279,13 +1236,11 @@ local function handleHandClick(x, y)
                 ui.lastTap.time = now
             end
             return true
-
         end
-        return true
     end
 
     local area = ui.areas.handBottom
-    if utils.inside(x, y, area.x, area.y, area.w, area.h) then
+    if area and utils.inside(x, y, area.x, area.y, area.w, area.h) then
         ui.drag = { active = true, id = "mouse", lastX = x }
         return true
     end
@@ -1402,6 +1357,9 @@ function ui.update(dt)
     if ui.game and ui.game.invalidTimer then
         ui.game.invalidTimer = math.max(0, ui.game.invalidTimer - dt)
     end
+    if ui.game and ui.game.reveal and ui.game.reveal.timer then
+        ui.game.reveal.timer = math.max(0, ui.game.reveal.timer - dt)
+    end
     if ui.game and ui.game.showPotOverlay and ui.game.reveal and ui.game.reveal.timer and ui.game.reveal.timer > 0 then
         ui.game.showPotOverlay = false
     end
@@ -1416,7 +1374,6 @@ function ui.toggleDebug()
 end
 
 --- Legacy helpers ---------------------------------------------------------------
-
 function ui.draw_end_screen(winner, players)
     local w, h = love.graphics.getWidth(), love.graphics.getHeight()
     love.graphics.setColor(0, 0, 0, 0.7)
@@ -1431,3 +1388,4 @@ function ui.draw_end_screen(winner, players)
 end
 
 return ui
+


### PR DESCRIPTION
## Summary
- rebuild the Love2D UI layout to drive info, opponent, center, hand, and button areas from shared card metrics and responsive spacing
- add an info panel with status hints, labeled deck/pot rendering, and a color-coded Pak/Speel/Pas button row tied to stored button state
- reorganize player and opponent card drawing to clip within their regions, render stacked face-down/open rows, and keep selection hitboxes in sync

## Testing
- luac -p ui.lua *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d14553f308832598c41de86c94b44e